### PR TITLE
New email options

### DIFF
--- a/src/sendgrid_java_wrapper/core.clj
+++ b/src/sendgrid_java_wrapper/core.clj
@@ -4,7 +4,7 @@
                          SendGrid$Response)))
 
 (defn- prepare-email [from subject html]
-  (println "from " from "subject " subject "html " html)
+  (println "from: " from " subject: " subject " html: " html)
   (-> (SendGrid$Email.)
      (.setFrom from)
      (.setSubject subject)
@@ -15,17 +15,41 @@
          email))
 
 (defn send-email
-  [auth {to :to from :from subject :subject html :html}]
+  [auth {to :to from :from subject :subject html :html from-name :from-name}]
   (let [email (-> (prepare-email from subject html)
-                 (.addTo to))
+                  (.addTo to)
+                  (.setFromName from-name))
+        response (-send auth email)]
+    (.getMessage response)))
+
+(defn send-email-groupid
+  [auth {to :to from :from subject :subject html :html from-name :from-name group-id :group-id}]
+  (let [email (-> (prepare-email from subject html)
+                  (.addTo to)
+                  (.setFromName from-name)
+                  (.setASMGroupId group-id))
         response (-send auth email)]
     (.getMessage response)))
 
 (defn bulk-email
-  [auth {bcc :bcc from :from subject :subject html :html}]
+  [auth {bcc :bcc from :from  subject :subject html :html from-name :from-name}]
   (println "[bulk email bcc] " bcc )
   (let [email (-> (prepare-email from subject html)
-                 (.setBcc (into-array String bcc)))
+                  (.setFromName from-name)
+                  (.setBcc (into-array String bcc)))
+        hack (dorun
+              (println "the super awesome email" (bean email))
+              (flush))
+        response (-send auth email)]
+    (.getMessage response)))
+
+(defn bulk-email-groupid
+  [auth {bcc :bcc from :from  subject :subject html :html from-name :from-name group-id :group-id}]
+  (println "[bulk email bcc] " bcc )
+  (let [email (-> (prepare-email from subject html)
+                  (.setFromName from-name)
+                  (.setASMGroupId group-id)
+                  (.setBcc (into-array String bcc)))
         hack (dorun
               (println "the super awesome email" (bean email))
               (flush))


### PR DESCRIPTION
Before you use this lib you should set your sendgrid account, at this point you can create some Groups for emails, so the user only unsubscribe from those groups and not for all of your emails. The lib doesn't need to create these groups.
Also, the email should be able to have a value on sendFromName.
